### PR TITLE
修复iview-loader替换时的误伤

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
     "loader-utils": "^1.1.0"
   },
   "devDependencies": {
+    "jest": "^24.1.0",
     "webpack": "^2.2.1"
   }
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -5,7 +5,7 @@ const { tag, prefixTag } = require('./tag-map');
 
 function replaceTag(source, tagMap) {
     Object.keys(tagMap).forEach(i => {
-        source = source.replace(new RegExp(`<${i}(?!-)`, 'g'), `<${tagMap[i]}`)
+        source = source.replace(new RegExp(`<${i}(?![-a-zA-Z])`, 'g'), `<${tagMap[i]}`)
             .replace(new RegExp(`<\/${i}>`, 'g'), `<\/${tagMap[i]}>`);
     })
     return source;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,0 +1,24 @@
+const originLoader = require('../src/loader')
+
+const baseLoaderContext = {
+  cacheable: () => { },
+}
+const normalLoader = originLoader.bind({
+  ...baseLoaderContext,
+  query: '?prefix=false',
+})
+
+const prefixLoader = originLoader.bind({
+  ...baseLoaderContext,
+  query: '?prefix=true',
+})
+
+test('替换该替换的标签', () => {
+  expect(normalLoader('<Circle></Circle>')).toBe('<i-circle></i-circle>')
+  expect(prefixLoader('<i-table></i-table>')).toBe('<Table></Table>')
+})
+
+test('不替换该不替换的标签', () => {
+  expect(normalLoader('<CircleLoading></CircleLoading>')).toBe('<CircleLoading></CircleLoading>')
+  expect(prefixLoader('<i-table-header></i-table-header>')).toBe('<i-table-header></i-table-header>')
+})


### PR DESCRIPTION
Circle在iview中指的是圆形进度条

iview-loader中会把`Circle`替换为`i-circle`以避免和web原生标签冲突

但匹配标签的正则只考虑了-分割的情况，会有误伤情况

比如下面代码中全局定义了一个CircleLoading组件

main.js
```javascript

import Vue from 'vue'
import App from './App'
import iView from 'iview'

Vue.config.productionTip = false

Vue.use(iView)
import CircleLoading from './components/CircleLoading'

Vue.component('CircleLoading', CircleLoading)
new Vue({
  el: '#app',
  components: { App },
  template: '<App/>'
})
```

app.vue
```vue
<template>
  <div id="app">
    <CircleLoading/>
  </div>
</template>

<script>

export default {
  name: 'App',
}
</script>

<style>
</style>

```

`CircleLoading`会被替换为`i-circleLoading`而产生如下warning

```
[Vue warn]: Unknown custom element: <i-circleLoading> - did you register the component correctly
```

对应修改了一下正则的匹配规则，添加了ut。